### PR TITLE
fix: DeepSeek 工具调用后 reasoning_content 未正确回传

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -466,6 +466,29 @@ class ChatCompletionsAPI(
         val requireReasoningContentForToolCalls =
             modelId.contains("deepseek", ignoreCase = true) || modelId.contains("kimi", ignoreCase = true)
 
+        // Identify indices belonging to turns (between user messages) that contain tool calls.
+        // DeepSeek/Kimi require reasoning_content from ALL assistant messages in such turns
+        // to be passed back in subsequent requests, not just the current turn.
+        val toolCallTurnIndices = if (requireReasoningContentForToolCalls) {
+            val indices = mutableSetOf<Int>()
+            val userIndices = messages.mapIndexedNotNull { i, m ->
+                if (m.role == MessageRole.USER) i else null
+            }
+            for (i in userIndices.indices) {
+                val turnStart = if (i == 0) 0 else userIndices[i - 1] + 1
+                val turnEnd = userIndices[i]
+                val turnHasToolCalls = (turnStart until turnEnd).any { idx ->
+                    messages[idx].role == MessageRole.ASSISTANT && messages[idx].getToolCalls().isNotEmpty()
+                }
+                if (turnHasToolCalls) {
+                    (turnStart until turnEnd).forEach { indices.add(it) }
+                }
+            }
+            indices
+        } else {
+            emptySet()
+        }
+
         messages.forEachIndexed { index, message ->
             if (!message.isValidToUpload()) return@forEachIndexed
 
@@ -572,10 +595,13 @@ class ChatCompletionsAPI(
                         .filterIsInstance<UIMessagePart.Reasoning>()
                         .firstOrNull()
                         ?.reasoning
+                    val inToolCallTurn = index in toolCallTurnIndices
                     val shouldAttachReasoningContent =
                         message.role == MessageRole.ASSISTANT &&
-                            index > lastUserMessageIndex &&
-                            (!reasoning.isNullOrBlank() || (requireReasoningContentForToolCalls && message.getToolCalls().isNotEmpty()))
+                            (inToolCallTurn && !reasoning.isNullOrBlank() || (
+                                index > lastUserMessageIndex &&
+                                    (!reasoning.isNullOrBlank() || (requireReasoningContentForToolCalls && message.getToolCalls().isNotEmpty()))
+                                ))
                     if (shouldAttachReasoningContent) {
                         put("reasoning_content", reasoning ?: "")
                     }

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPITest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPITest.kt
@@ -90,6 +90,43 @@ class ChatCompletionsAPITest {
     }
 
     @Test
+    fun `deepseek should pass back reasoning_content from previous tool-call turns`() {
+        val api = ChatCompletionsAPI(OkHttpClient(), KeyRoulette.default())
+        val messages = listOf(
+            // Turn 1: user asks, assistant calls tool
+            UIMessage(role = MessageRole.USER, parts = listOf(UIMessagePart.Text("搜天气"))),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "reasoning_A"),
+                    UIMessagePart.ToolCall(toolCallId = "call_1", toolName = "weather", arguments = "{}"),
+                    UIMessagePart.Text("")
+                )
+            ),
+            UIMessage(
+                role = MessageRole.TOOL,
+                parts = listOf(UIMessagePart.ToolResult(toolCallId = "call_1", toolName = "weather", content = kotlinx.serialization.json.JsonPrimitive("晴天"), arguments = kotlinx.serialization.json.JsonObject(emptyMap())))
+            ),
+            // Turn 1 continued: assistant responds after tool
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "reasoning_B"),
+                    UIMessagePart.Text("晴天")
+                )
+            ),
+            // Turn 2: follow-up question
+            UIMessage(role = MessageRole.USER, parts = listOf(UIMessagePart.Text("那明天呢？"))),
+        )
+
+        val json = buildMessagesJson(api, messages, modelId = "deepseek-v3.2")
+        // Index 1: assistant with tool call from turn 1
+        assertEquals("reasoning_A", json[1].jsonObject["reasoning_content"]?.jsonPrimitive?.content)
+        // Index 3: assistant response after tool in turn 1
+        assertEquals("reasoning_B", json[3].jsonObject["reasoning_content"]?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun `previous turn reasoning should not be uploaded`() {
         val api = ChatCompletionsAPI(OkHttpClient(), KeyRoulette.default())
         val messages = listOf(


### PR DESCRIPTION
## 问题

DeepSeek API 在开启 thinking 模式且使用工具调用时，要求中间 assistant 消息的 `reasoning_content` 在后续**所有请求**中回传。

当前代码只回传当前轮次（`index > lastUserMessageIndex`）的 reasoning_content，导致多轮对话中之前轮次的 tool call reasoning 被丢弃，API 返回报错：
> The `reasoning_content` in the thinking mode must be passed back to the API.

## 修复

- 预先分析所有包含工具调用的轮次（两次 user 消息之间有 tool_call 的消息段）
- 对于 DeepSeek/Kimi，只要 assistant 消息属于包含 tool call 的轮次且有 reasoning_content，始终回传
- 其他模型保持原有行为不变
- 新增单测覆盖多轮 tool call 场景