### PR TITLE
fix: eval_javascript 工具 console.log 报错，每次都要失败一次才能成功

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/LocalTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/LocalTools.kt
@@ -1,6 +1,7 @@
 package me.rerere.rikkahub.data.ai.tools
 
 import android.content.Context
+import com.whl.quickjs.android.QuickJSLoader
 import com.whl.quickjs.wrapper.QuickJSContext
 import com.whl.quickjs.wrapper.QuickJSObject
 import kotlinx.serialization.SerialName
@@ -42,16 +43,31 @@ class LocalTools(private val context: Context) {
                 )
             },
             execute = {
-                val context = QuickJSContext.create()
-                val code = it.jsonObject["code"]?.jsonPrimitive?.contentOrNull
-                val result = context.evaluate(code)
-                buildJsonObject {
-                    put(
-                        "result", when (result) {
-                            is QuickJSObject -> JsonPrimitive(result.stringify())
-                            else -> JsonPrimitive(result.toString())
+                QuickJSLoader.init()
+                val jsContext = QuickJSContext.create()
+                try {
+                    val logs = StringBuilder()
+                    jsContext.setConsole(object : QuickJSContext.Console {
+                        override fun log(info: String) { logs.appendLine(info) }
+                        override fun info(info: String) { logs.appendLine(info) }
+                        override fun warn(info: String) { logs.appendLine(info) }
+                        override fun error(info: String) { logs.appendLine(info) }
+                    })
+                    val code = it.jsonObject["code"]?.jsonPrimitive?.contentOrNull
+                    val result = jsContext.evaluate(code)
+                    buildJsonObject {
+                        put(
+                            "result", when (result) {
+                                is QuickJSObject -> JsonPrimitive(result.stringify())
+                                else -> JsonPrimitive(result.toString())
+                            }
+                        )
+                        if (logs.isNotEmpty()) {
+                            put("console_output", JsonPrimitive(logs.toString().trimEnd()))
                         }
-                    )
+                    }
+                } finally {
+                    jsContext.destroy()
                 }
             }
         )


### PR DESCRIPTION
## 问题

eval_javascript 工具里，AI 写的 JS 代码只要带 `console.log()`，就报错 "stdout 没有配置"。

实际使用中的表现：每次调 JS 工具都得失败一次。AI 第一次写代码习惯用 `console.log` 输出结果，工具报错；AI 看到报错后换个写法不用 `console.log`，第二次才成功。白白浪费一轮调用。

## 原因

`LocalTools.kt` 里 `QuickJSContext.create()` 之后没有调 `setConsole()`。

QuickJS wrapper 库内部的 console 实现里，默认的 `stdout` 就是直接抛异常，必须通过 `setConsole()` 接上输出通道才能用。

## 改了什么

只动了一个文件：`app/src/main/java/me/rerere/rikkahub/data/ai/tools/LocalTools.kt`

- 创建 QuickJSContext 后调 `setConsole()`，把 `console.log` / `info` / `warn` / `error` 的输出收集到 StringBuilder
- 返回结果时，原有的 `result` 字段不变；有 console 输出时多返回一个 `console_output` 字段
- `try/finally` 包裹，`finally` 里 `destroy()` 释放 QuickJSContext，原来没有释放，用一次泄漏一次
- 加了 `QuickJSLoader.init()` 确保原生库已加载，不默认依赖 Highlighter 模块先启动

## 测试建议

我这边没有 Android 开发环境，麻烦作者帮忙跑一下这三种情况：

```javascript
// 1. 纯 console.log（之前会报错的场景）
console.log(1 + 1)

// 2. 表达式直接返回结果（不用 console.log）
const x = 2 + 3
x

// 3. 两者都有
console.log({ a: 1 })
;({ ok: true })
```

## 备注

这个问题是用 GPT Codex 和 Claude Code 交叉分析排查出来的，两边独立确认了根因和修复方案。