### PR TITLE
fix: prevent crash when reading unreadable response body in Grok SSE onFailure

### DIFF
--- a/search/src/main/java/me/rerere/search/GrokSearchService.kt
+++ b/search/src/main/java/me/rerere/search/GrokSearchService.kt
@@ -171,7 +171,7 @@ object GrokSearchService : SearchService<SearchServiceOptions.GrokOptions> {
 
                 override fun onFailure(eventSource: EventSource, t: Throwable?, response: okhttp3.Response?) {
                     val statusCode = response?.code ?: -1
-                    val body = response?.body?.string().orEmpty()
+                    val body = runCatching { response?.body?.string() }.getOrNull().orEmpty()
                     streamError = Exception("Stream failed #$statusCode: $body", t)
                     close(streamError)
                 }


### PR DESCRIPTION
## Problem
GrokSearchService 的 SSE 流式搜索在 `onFailure` 回调中直接调用 `response?.body?.string()`，当 OkHttp 传入的 response body 是 `UnreadableResponseBody` 时（网络错误、连接中断等场景），会抛出 `IllegalStateException` 导致崩溃。

## Fix
用 `runCatching` 包裹 body 读取，读不到时返回空字符串。正常流程不受影响，仅防崩溃。

## Stack trace reference
```
java.lang.IllegalStateException: Unreadable ResponseBody!
  at okhttp3.internal.UnreadableResponseBody.read(...)
  at okhttp3.ResponseBody.string(...)
  at me.rerere.search.GrokSearchService$searchWithStreaming$2$listener$1.onFailure(...)
```