### PR TITLE
feat: add global crash handler and make Firebase optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ settings.local.json
 /.gradle-user
 /.jdks
 .claude/settings.local.json
+/plans

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,9 +14,14 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.google.services)
-    alias(libs.plugins.firebase.crashlytics)
+    // alias(libs.plugins.google.services)
+    // alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.chaquopy)
+}
+
+if (file("google-services.json").exists()) {
+    apply(plugin = "com.google.gms.google-services")
+    apply(plugin = "com.google.firebase.crashlytics")
 }
 
 private data class LocalBuildMeta(

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,11 +42,17 @@
     android:usesCleartextTraffic="true"
     tools:targetApi="33">
     <activity
-      android:name=".RouteActivity"
-      android:configChanges="keyboardHidden|orientation|screenSize"
-      android:exported="true"
-      android:theme="@style/Theme.Rikkahub"
-      android:windowSoftInputMode="adjustResize">
+        android:name=".ui.activity.CrashActivity"
+        android:process=":crash"
+        android:theme="@style/Theme.Rikkahub"
+        android:screenOrientation="portrait"
+        android:exported="false" />
+        <activity
+            android:name=".RouteActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:exported="true"
+            android:theme="@style/Theme.Rikkahub"
+            android:windowSoftInputMode="adjustResize">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/me/rerere/rikkahub/LastChatApp.kt
+++ b/app/src/main/java/me/rerere/rikkahub/LastChatApp.kt
@@ -92,6 +92,10 @@ class LastChatApp : Application(), SingletonImageLoader.Factory {
     override fun onCreate() {
         super.onCreate()
         instance = this
+
+        // Global Crash Handler
+        me.rerere.rikkahub.utils.CrashHandler.init(this)
+
         startKoin {
             androidLogger()
             androidContext(this@LastChatApp)

--- a/app/src/main/java/me/rerere/rikkahub/ui/activity/CrashActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/activity/CrashActivity.kt
@@ -1,0 +1,193 @@
+package me.rerere.rikkahub.ui.activity
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ContentCopy
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.RestartAlt
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import me.rerere.rikkahub.R
+import me.rerere.rikkahub.RouteActivity
+import me.rerere.rikkahub.ui.components.ui.ViewText
+import me.rerere.rikkahub.ui.pages.setting.components.SettingsGroup
+import java.io.File
+import kotlin.system.exitProcess
+
+class CrashActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        val crashFilePath = intent.getStringExtra("crash_file")
+        val crashLog = crashFilePath?.let { File(it).run { if (exists()) readText() else "No log found" } } ?: "No crash file provided"
+
+        setContent {
+            // We use standard MaterialTheme here to avoid Koin/SettingsStore dependencies 
+            // in the crash process for maximum reliability.
+            MaterialTheme {
+                CrashScreen(
+                    log = crashLog,
+                    onRestart = { restartApp() },
+                    onCopy = { copyToClipboard(crashLog) }
+                )
+            }
+        }
+    }
+
+    private fun copyToClipboard(text: String) {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText("Crash Log", text)
+        clipboard.setPrimaryClip(clip)
+    }
+
+    private fun restartApp() {
+        val intent = Intent(this, RouteActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.set(AlarmManager.RTC, System.currentTimeMillis() + 500, pendingIntent)
+
+        // Kill current process
+        android.os.Process.killProcess(android.os.Process.myPid())
+        exitProcess(10)
+    }
+}
+
+@Composable
+private fun CrashScreen(
+    log: String,
+    onRestart: () -> Unit,
+    onCopy: () -> Unit
+) {
+    val haptic = LocalHapticFeedback.current
+    
+    Scaffold(
+        bottomBar = {
+            Surface(
+                tonalElevation = 8.dp,
+                shadowElevation = 8.dp
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                        .padding(bottom = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Button(
+                        onClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onCopy()
+                        },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                    ) {
+                        Icon(Icons.Rounded.ContentCopy, null)
+                        Text(modifier = Modifier.padding(start = 8.dp), text = stringResource(R.string.copy))
+                    }
+
+                    Button(
+                        onClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onRestart()
+                        },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Icon(Icons.Rounded.RestartAlt, null)
+                        Text(modifier = Modifier.padding(start = 8.dp), text = stringResource(R.string.restart))
+                    }
+                }
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                Icons.Rounded.ErrorOutline,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.error
+            )
+
+            Text(
+                text = stringResource(R.string.crash_oops),
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.error
+            )
+
+            Text(
+                text = stringResource(R.string.crash_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            SettingsGroup(title = stringResource(R.string.crash_details)) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = MaterialTheme.shapes.medium
+                ) {
+                    ViewText(
+                        text = log,
+                        modifier = Modifier.padding(12.dp),
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/utils/CrashHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/CrashHandler.kt
@@ -1,0 +1,69 @@
+package me.rerere.rikkahub.utils
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import me.rerere.rikkahub.BuildConfig
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import kotlin.system.exitProcess
+
+/**
+ * Global Crash Handler to capture uncaught exceptions and show a friendly crash screen.
+ */
+class CrashHandler(private val context: Context) : Thread.UncaughtExceptionHandler {
+    private val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+
+    override fun uncaughtException(thread: Thread, throwable: Throwable) {
+        try {
+            // 1. Generate Crash Report
+            val report = buildString {
+                appendLine("LastChat Crash Report")
+                appendLine("========================")
+                appendLine("Time: ${System.currentTimeMillis()}")
+                appendLine("App Version: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+                appendLine("Flavor: ${BuildConfig.FLAVOR}")
+                appendLine("Device: ${Build.BRAND} ${Build.MODEL} (SDK ${Build.VERSION.SDK_INT})")
+                appendLine("Thread: ${thread.name}")
+                appendLine()
+                appendLine("Exception:")
+                val sw = StringWriter()
+                val pw = PrintWriter(sw)
+                throwable.printStackTrace(pw)
+                appendLine(sw.toString())
+                appendLine("========================")
+            }
+
+            // 2. Save to Cache File (Avoid Intent Size Limit)
+            val crashFile = File(context.cacheDir, "crash_report.txt")
+            crashFile.writeText(report)
+
+            // 3. Launch CrashActivity
+            // We use a string for the class name to avoid direct dependency issues if needed,
+            // but here we know the package.
+            val intent = Intent().apply {
+                setClassName(context.packageName, "me.rerere.rikkahub.ui.activity.CrashActivity")
+                putExtra("crash_file", crashFile.absolutePath)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            }
+            context.startActivity(intent)
+
+            // 4. Terminate Process
+            android.os.Process.killProcess(android.os.Process.myPid())
+            exitProcess(10)
+        } catch (e: Exception) {
+            Log.e("CrashHandler", "Error during crash handling", e)
+            // Fallback to default handler if our handler fails
+            defaultHandler?.uncaughtException(thread, throwable)
+        }
+    }
+
+    companion object {
+        fun init(context: Context) {
+            val handler = CrashHandler(context)
+            Thread.setDefaultUncaughtExceptionHandler(handler)
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/utils/CrashHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/CrashHandler.kt
@@ -37,7 +37,7 @@ class CrashHandler(private val context: Context) : Thread.UncaughtExceptionHandl
             }
 
             // 2. Save to Cache File (Avoid Intent Size Limit)
-            val crashFile = File(context.cacheDir, "crash_report.txt")
+            val crashFile = File(context.cacheDir, "crash_${System.currentTimeMillis()}.txt")
             crashFile.writeText(report)
 
             // 3. Launch CrashActivity

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -515,4 +515,8 @@
     <string name="quota_group_keep_one_model">组内至少保留一个模型。</string>
     <string name="quota_group_delete">删除限额组</string>
     <string name="quota_group_delete_confirm">删除这个限额组吗？模型会保留各自的单独限额设置。</string>
+    <string name="restart">重新启动</string>
+    <string name="crash_oops">糟糕！出了点问题</string>
+    <string name="crash_desc">应用程序遇到了意外错误，需要重新启动。您可以复制下面的错误详情，以帮助我们修复问题。</string>
+    <string name="crash_details">错误详情</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2106,4 +2106,8 @@
     <string name="quota_group_delete">刪除限額組</string>
     <string name="quota_group_delete_confirm">刪除這個限額組嗎？模型會保留各自的單獨限額設定。</string>
 
+    <string name="restart">重新啟動</string>
+    <string name="crash_oops">糟糕！出了點問題</string>
+    <string name="crash_desc">應用程式遇到了意外錯誤，需要重新啟動。您可以複製下面的錯誤詳情，以幫助我們修復問題。</string>
+    <string name="crash_details">錯誤詳情</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2116,4 +2116,8 @@
     <string name="quota_group_delete">Delete quota group</string>
     <string name="quota_group_delete_confirm">Delete this quota group? Models will keep their single-model quota settings.</string>
 
+    <string name="restart">Restart</string>
+    <string name="crash_oops">Oops! Something went wrong</string>
+    <string name="crash_desc">The application encountered an unexpected error and needs to restart. You can copy the error details below to help us fix the issue.</string>
+    <string name="crash_details">Crash Details</string>
 </resources>

--- a/web-ui/app/components/markdown/markdown.tsx
+++ b/web-ui/app/components/markdown/markdown.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { Streamdown, useIsCodeFenceIncomplete } from "streamdown";
+import { Streamdown } from "streamdown";
 import { cjk } from "@streamdown/cjk";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -149,20 +149,19 @@ export default function Markdown({
 
   function MarkdownCode(componentProps: Record<string, unknown> & { children?: React.ReactNode }) {
     const { className, children, ...props } = componentProps;
-    const isIncomplete = useIsCodeFenceIncomplete();
     const codeClassName = typeof className === "string" ? className : "";
     const match = /language-([A-Za-z0-9_-]+)/.exec(codeClassName);
     const code = String(children).replace(/\n$/, "");
     const isBlock = code.includes("\n");
 
-    if (match || isBlock || isIncomplete) {
+    if (match || isBlock) {
       const language = match?.[1] || "";
       return (
         <CodeBlock
           language={language}
           code={code}
           autoCollapse={displaySetting?.codeBlockAutoCollapse ?? true}
-          isIncomplete={isIncomplete}
+          isIncomplete={false}
           showLineNumbers={displaySetting?.showLineNumbers ?? false}
           wrapLines={displaySetting?.codeBlockAutoWrap ?? false}
           onPreview={

--- a/web-ui/app/components/markdown/markdown.tsx
+++ b/web-ui/app/components/markdown/markdown.tsx
@@ -154,6 +154,7 @@ export default function Markdown({
     const code = String(children).replace(/\n$/, "");
     const isBlock = code.includes("\n");
 
+    // Note: `isIncomplete` check removed — see TODO below
     if (match || isBlock) {
       const language = match?.[1] || "";
       return (
@@ -161,6 +162,9 @@ export default function Markdown({
           language={language}
           code={code}
           autoCollapse={displaySetting?.codeBlockAutoCollapse ?? true}
+          // TODO: `useIsCodeFenceIncomplete` was removed in the streamdown library update.
+          // Hardcoded to false as a temporary workaround. Code blocks during streaming
+          // may not render correctly until this is resolved upstream.
           isIncomplete={false}
           showLineNumbers={displaySetting?.showLineNumbers ?? false}
           wrapLines={displaySetting?.codeBlockAutoWrap ?? false}

--- a/web-ui/bun.lock
+++ b/web-ui/bun.lock
@@ -1,10 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "web-ui",
       "dependencies": {
+        "@material-symbols/svg-400": "^0.40.2",
         "@react-router/node": "7.13.0",
         "@react-router/serve": "7.13.0",
         "@streamdown/cjk": "^1.0.2",
@@ -188,6 +188,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@material-symbols/svg-400": ["@material-symbols/svg-400@0.40.2", "", {}, "sha512-e2yEgZW/OveVT1sGaZW1kkRWTPVghjsJYWy+vIea3q08Fv2o7FCYv23PESMyr5D4AaAXdM5dKWkF1e6yIm4swA=="],
 
     "@mjackson/node-fetch-server": ["@mjackson/node-fetch-server@0.2.0", "", {}, "sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng=="],
 


### PR DESCRIPTION
## What this PR does

Adds a custom global crash handler that replaces silent crashes with a
user-friendly crash screen. Also makes Firebase/Google Services optional
so the project can be built without `google-services.json`.

## Changes

### Global Crash Handler
- `CrashHandler.kt` — captures uncaught exceptions, writes a timestamped
  crash report to `cacheDir`, then launches `CrashActivity` in an isolated
  process.
- `CrashActivity.kt` — displays the crash log with Copy and Restart actions.
  Uses plain `MaterialTheme` (no Koin/DI) for maximum reliability in a
  crashed state.
- `android:process=":crash"` — crash UI runs in a separate process so a
  corrupted main process doesn't affect it.

### Firebase Optional
- `google.services` and `firebase.crashlytics` plugins are now applied
  conditionally only when `google-services.json` exists.
- Allows contributors to build the project without a Firebase setup.

### Markdown Fix
- Removed `useIsCodeFenceIncomplete` which no longer exists in the updated
  `streamdown` library. Hardcoded to `false` as a temporary workaround.
  A TODO comment is left at the call site until this is resolved upstream.

## Notes

- The crash handler is initialized in `Application.onCreate()` before Koin,
  so it catches DI initialization failures too.
- Crash files are timestamped (`crash_<ms>.txt`) to avoid overwriting on
  consecutive crashes.