### PR TITLE
feat: custom prompts for local tools

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/LocalTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/LocalTools.kt
@@ -587,19 +587,32 @@ class LocalTools(
         }.getOrNull()
     }
 
-    fun getTools(options: List<LocalToolOption>, assistantId: Uuid, conversationId: Uuid): List<Tool> {
+    fun getTools(
+        options: List<LocalToolOption>,
+        assistantId: Uuid,
+        conversationId: Uuid,
+        customPrompts: Map<String, String> = emptyMap(),
+    ): List<Tool> {
         val tools = mutableListOf<Tool>()
         if (options.contains(LocalToolOption.JavascriptEngine)) {
-            tools.add(javascriptTool)
+            tools.add(javascriptTool.applyCustomPrompt(customPrompts["eval_javascript"]))
         }
         if (options.contains(LocalToolOption.DeviceControl)) {
-            tools.addAll(getDeviceControlTools(assistantId, conversationId))
+            tools.addAll(
+                getDeviceControlTools(assistantId, conversationId)
+                    .map { it.applyCustomPrompt(customPrompts[it.name]) }
+            )
         }
         if (options.contains(LocalToolOption.ScheduledTaskManager)) {
-            tools.addAll(createScheduledTaskTools(assistantId, scheduledTaskDao, scheduledTaskScheduler))
+            tools.addAll(
+                createScheduledTaskTools(assistantId, scheduledTaskDao, scheduledTaskScheduler)
+                    .map { it.applyCustomPrompt(customPrompts[it.name]) }
+            )
         }
         return tools
     }
+
+    companion object
 }
 
 internal fun buildJavascriptToolResult(result: Any?, consoleOutput: String): JsonObject = buildJsonObject {
@@ -614,4 +627,19 @@ internal fun buildJavascriptToolResult(result: Any?, consoleOutput: String): Jso
     if (consoleOutput.isNotEmpty()) {
         put("console_output", JsonPrimitive(consoleOutput.trimEnd()))
     }
+}
+
+/**
+ * Append a user-provided custom prompt to a tool's description.
+ * Returns the original tool unchanged if the custom prompt is blank.
+ */
+internal fun Tool.applyCustomPrompt(customPrompt: String?): Tool {
+    if (customPrompt.isNullOrBlank()) return this
+    return copy(
+        description = buildString {
+            append(description)
+            append("\n\nUser instructions: ")
+            append(customPrompt.trim())
+        }
+    )
 }

--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -114,6 +114,7 @@ data class Assistant(
     val customBodies: List<CustomBody> = emptyList(),
     val mcpServers: Set<Uuid> = emptySet(),
     val localTools: List<LocalToolOption> = emptyList(),
+    val localToolCustomPrompts: Map<String, String> = emptyMap(), // key: tool name (e.g. "ask_user"), value: custom prompt appended to tool description
     val enabledSkillIds: Set<Uuid> = emptySet(), // Skills enabled for this assistant
     val enabledModeIds: Set<Uuid> = emptySet(), // Modes enabled by default for new chats of this assistant
     val background: String? = null,

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -90,6 +90,7 @@ import me.rerere.rikkahub.data.ai.tools.EVAL_PYTHON_SYSTEM_PROMPT_TEMPLATE
 import me.rerere.rikkahub.data.ai.tools.LorebookTools
 import me.rerere.rikkahub.data.ai.tools.LocalToolOption
 import me.rerere.rikkahub.data.ai.tools.LocalTools
+import me.rerere.rikkahub.data.ai.tools.applyCustomPrompt
 import me.rerere.rikkahub.data.ai.tools.RUN_SKILL_SCRIPT_SYSTEM_PROMPT_TEMPLATE
 import me.rerere.rikkahub.data.ai.tools.SCRIPTABLE_SKILL_LIST_VARIABLE
 import me.rerere.rikkahub.data.ai.tools.SkillScriptRunner
@@ -1867,7 +1868,8 @@ class ChatService(
                     addAll(localTools.getTools(
                         options = assistant.localTools,
                         assistantId = assistant.id,
-                        conversationId = conversation.id
+                        conversationId = conversation.id,
+                        customPrompts = assistant.localToolCustomPrompts
                     ))
                     if (assistant.localTools.contains(LocalToolOption.MemorySearch)) {
                         addAll(
@@ -1938,7 +1940,8 @@ class ChatService(
                         )
                     }
                     if (assistant.localTools.contains(LocalToolOption.AskUser)) {
-                        add(createAskUserTool(conversationId = conversation.id))
+                        add(createAskUserTool(conversationId = conversation.id)
+                            .applyCustomPrompt(assistant.localToolCustomPrompts["ask_user"]))
                     }
                 },
                 truncateIndex = conversation.truncateIndex,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantToolsSubPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantToolsSubPage.kt
@@ -21,11 +21,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import me.rerere.rikkahub.ui.components.ui.HapticSwitch
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -50,6 +56,56 @@ import me.rerere.rikkahub.ui.pages.setting.components.SettingGroupItem
 import kotlin.uuid.Uuid
 
 /**
+ * Map LocalToolOption to the actual tool name used in Tool.description.
+ * Used as the key for localToolCustomPrompts.
+ */
+private fun LocalToolOption.toolName(): String? = when (this) {
+    LocalToolOption.JavascriptEngine -> "eval_javascript"
+    LocalToolOption.AskUser -> "ask_user"
+    LocalToolOption.DeviceControl -> null // multiple tools, not supported
+    LocalToolOption.WorkspaceFiles -> null // multiple tools, not supported
+    LocalToolOption.LorebooksEditor -> null
+    LocalToolOption.ScheduledTaskManager -> null // multiple tools
+    LocalToolOption.MemorySearch -> null
+    LocalToolOption.ChatSearch -> null
+    LocalToolOption.PythonEngine -> null
+}
+
+@Composable
+private fun CustomPromptDialog(
+    toolTitle: String,
+    currentValue: String,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit,
+) {
+    var text by remember(currentValue) { mutableStateOf(currentValue) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Custom Prompt") },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                label = { Text("Additional instructions for $toolTitle") },
+                placeholder = { Text("e.g. Only use this tool when absolutely necessary") },
+                modifier = Modifier.fillMaxSize(),
+                maxLines = 6
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onSave(text.trim()) }) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+/**
  * Tools tab - Local tools and MCP settings.
  * Designed with cohesive SettingsGroup pattern.
  */
@@ -65,6 +121,7 @@ fun AssistantToolsSubPage(
 
     var expandedFolderIds by remember { mutableStateOf<Set<Uuid>>(emptySet()) }
     var ungroupedExpanded by remember { mutableStateOf(false) }
+    var editingToolName by remember { mutableStateOf<String?>(null) }
     
     Column(
         modifier = Modifier
@@ -89,17 +146,24 @@ fun AssistantToolsSubPage(
                 title = stringResource(R.string.assistant_page_local_tools_javascript_engine_title),
                 subtitle = stringResource(R.string.assistant_page_local_tools_javascript_engine_desc),
                 trailing = {
-                    HapticSwitch(
-                        checked = assistant.localTools.contains(LocalToolOption.JavascriptEngine),
-                        onCheckedChange = { enabled ->
-                            val newLocalTools = if (enabled) {
-                                assistant.localTools + LocalToolOption.JavascriptEngine
-                            } else {
-                                assistant.localTools - LocalToolOption.JavascriptEngine
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        if (assistant.localTools.contains(LocalToolOption.JavascriptEngine)) {
+                            FilledTonalIconButton(onClick = { editingToolName = "eval_javascript" }) {
+                                Icon(Icons.Rounded.Edit, contentDescription = "Edit custom prompt", modifier = Modifier.size(18.dp))
                             }
-                            onUpdate(assistant.copy(localTools = newLocalTools))
                         }
-                    )
+                        HapticSwitch(
+                            checked = assistant.localTools.contains(LocalToolOption.JavascriptEngine),
+                            onCheckedChange = { enabled ->
+                                val newLocalTools = if (enabled) {
+                                    assistant.localTools + LocalToolOption.JavascriptEngine
+                                } else {
+                                    assistant.localTools - LocalToolOption.JavascriptEngine
+                                }
+                                onUpdate(assistant.copy(localTools = newLocalTools))
+                            }
+                        )
+                    }
                 }
             )
 
@@ -222,17 +286,24 @@ fun AssistantToolsSubPage(
                 title = stringResource(R.string.assistant_page_local_tools_ask_user_title),
                 subtitle = stringResource(R.string.assistant_page_local_tools_ask_user_desc),
                 trailing = {
-                    HapticSwitch(
-                        checked = assistant.localTools.contains(LocalToolOption.AskUser),
-                        onCheckedChange = { enabled ->
-                            val newLocalTools = if (enabled) {
-                                assistant.localTools + LocalToolOption.AskUser
-                            } else {
-                                assistant.localTools - LocalToolOption.AskUser
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        if (assistant.localTools.contains(LocalToolOption.AskUser)) {
+                            FilledTonalIconButton(onClick = { editingToolName = "ask_user" }) {
+                                Icon(Icons.Rounded.Edit, contentDescription = "Edit custom prompt", modifier = Modifier.size(18.dp))
                             }
-                            onUpdate(assistant.copy(localTools = newLocalTools))
                         }
-                    )
+                        HapticSwitch(
+                            checked = assistant.localTools.contains(LocalToolOption.AskUser),
+                            onCheckedChange = { enabled ->
+                                val newLocalTools = if (enabled) {
+                                    assistant.localTools + LocalToolOption.AskUser
+                                } else {
+                                    assistant.localTools - LocalToolOption.AskUser
+                                }
+                                onUpdate(assistant.copy(localTools = newLocalTools))
+                            }
+                        )
+                    }
                 }
             )
 
@@ -495,5 +566,24 @@ fun AssistantToolsSubPage(
                 )
             }
         }
+    }
+
+    // Custom prompt edit dialog
+    editingToolName?.let { toolName ->
+        val currentPrompt = assistant.localToolCustomPrompts[toolName].orEmpty()
+        CustomPromptDialog(
+            toolTitle = toolName,
+            currentValue = currentPrompt,
+            onDismiss = { editingToolName = null },
+            onSave = { newPrompt ->
+                val updatedPrompts = if (newPrompt.isBlank()) {
+                    assistant.localToolCustomPrompts - toolName
+                } else {
+                    assistant.localToolCustomPrompts + (toolName to newPrompt)
+                }
+                onUpdate(assistant.copy(localToolCustomPrompts = updatedPrompts))
+                editingToolName = null
+            }
+        )
     }
 }


### PR DESCRIPTION
## Summary

Allow users to add custom instructions/prompts to individual local tools (e.g. `ask_user`, `eval_javascript`) to constrain their usage behavior. The custom prompt is appended to the tool's description sent to the AI model.

## Changes

- **Assistant.kt**: Add `localToolCustomPrompts: Map<String, String>` field (default emptyMap, backward compatible)
- **LocalTools.kt**: Add `applyCustomPrompt` extension function; modify `getTools()` to accept `customPrompts` parameter and apply them to tool descriptions
- **ChatService.kt**: Pass `assistant.localToolCustomPrompts` to `localTools.getTools()` and apply to `ask_user` tool
- **AssistantToolsSubPage.kt**: Add edit button (pencil icon) next to JavaScript Engine and Ask User switches; add `CustomPromptDialog` for editing custom prompts

## How it works

1. Enable a tool (e.g. Ask User) in the assistant settings
2. Tap the edit icon that appears next to the switch
3. Enter custom instructions (e.g. "Only use this tool for critical decisions, not for trivial questions")
4. The instructions are appended to the tool description as `\n\nUser instructions: ...`

## Backward compatibility

No data migration needed — the new field has a default value of `emptyMap()`, so existing Assistant data deserializes without changes.