### PR TITLE
fix: 排除当前对话在最近对话参考注入中的干扰

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -1054,8 +1054,9 @@ class GenerationHandler(
                 val recentConversations = conversationRepo.getRecentConversations(
                     assistantId = assistant.id,
                     limit = 3,
-                ).filter { 
-                    java.time.LocalDateTime.ofInstant(it.updateAt, java.time.ZoneId.systemDefault()).toLocalDate() == today 
+                ).filter {
+                    java.time.LocalDateTime.ofInstant(it.updateAt, java.time.ZoneId.systemDefault()).toLocalDate() == today
+                        && it.id != conversationId
                 }
                 recentConversations.map { conversation ->
                     AssistantMemory(


### PR DESCRIPTION
## 问题

`enableRecentChatsReference` 功能会把当前对话也注入到 context 中（因为当前对话 `update_at` 最新排在第一位），导致助手误认为这件事已经聊过了。

## 修复

在 `GenerationHandler.kt` 的 filter 条件中增加 `it.id != conversationId`，排除当前对话。

## 影响范围

仅影响 `messages.size <= 2`（新对话/刚开头）时的最近对话参考注入逻辑。
