### PR TITLE
fix: normalize empty tool parameter schemas

### DIFF
--- a/ai/src/main/java/me/rerere/ai/core/Tool.kt
+++ b/ai/src/main/java/me/rerere/ai/core/Tool.kt
@@ -18,6 +18,10 @@ data class Tool(
     val execute: suspend (JsonElement) -> JsonElement
 )
 
+fun Tool.parametersOrEmptyObject(): InputSchema {
+    return parameters() ?: InputSchema.Obj(properties = JsonObject(emptyMap()))
+}
+
 @Serializable
 sealed class InputSchema {
     @Serializable

--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.json.putJsonArray
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.core.parametersOrEmptyObject
 import me.rerere.ai.provider.BuiltInTools
 import me.rerere.ai.provider.ImageGenerationParams
 import me.rerere.ai.provider.Model
@@ -408,7 +409,7 @@ class ClaudeProvider(private val client: OkHttpClient) : Provider<ProviderSettin
                         add(buildJsonObject {
                             put("name", tool.name)
                             put("description", tool.description)
-                            put("input_schema", json.encodeToJsonElement(tool.parameters()))
+                            put("input_schema", json.encodeToJsonElement(tool.parametersOrEmptyObject()))
                         })
                     }
                     builtInTools.forEach { add(it) }

--- a/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.putJsonObject
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.core.parametersOrEmptyObject
 import me.rerere.ai.provider.BuiltInTools
 import me.rerere.ai.provider.ImageGenerationParams
 import me.rerere.ai.provider.Modality
@@ -487,7 +488,7 @@ class GoogleProvider(private val client: OkHttpClient) : Provider<ProviderSettin
                                 put("description", JsonPrimitive(tool.description))
                                 put(
                                     key = "parameters",
-                                    element = json.encodeToJsonElement(tool.parameters())
+                                    element = json.encodeToJsonElement(tool.parametersOrEmptyObject())
                                         .removeElements(
                                             listOf(
                                                 "const",

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.putJsonArray
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.core.parametersOrEmptyObject
 import me.rerere.ai.provider.Modality
 import me.rerere.ai.provider.Model
 import me.rerere.ai.provider.ModelAbility
@@ -443,7 +444,7 @@ class ChatCompletionsAPI(
                                 put(
                                     "parameters",
                                     json.encodeToJsonElement(
-                                        tool.parameters()
+                                        tool.parametersOrEmptyObject()
                                     )
                                 )
                             })

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.putJsonArray
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.core.parametersOrEmptyObject
 import me.rerere.ai.provider.BuiltInTools
 import me.rerere.ai.provider.Model
 import me.rerere.ai.provider.ModelAbility
@@ -297,7 +298,7 @@ class ResponseAPI(
                                 put(
                                     "parameters",
                                     json.encodeToJsonElement(
-                                        tool.parameters()
+                                        tool.parametersOrEmptyObject()
                                     )
                                 )
                             })

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/ScheduledTaskTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/ScheduledTaskTools.kt
@@ -38,7 +38,9 @@ fun createScheduledTaskTools(
 private fun buildListTool(assistantId: Uuid, taskDao: ScheduledTaskDao) = Tool(
     name = "list_scheduled_tasks",
     description = "List scheduled tasks.",
-    parameters = { null },
+    parameters = {
+        InputSchema.Obj(properties = buildJsonObject { })
+    },
     systemPrompt = { _, _ -> SCHEDULED_TASK_SYSTEM_PROMPT_TEMPLATE },
     execute = {
         val ids = withContext(Dispatchers.IO) {


### PR DESCRIPTION
## Summary

Fixes #64.

This PR prevents Gemini `gemini-3-flash-preview` requests from failing when a tool has no parameters. Google function declarations require `parameters` to be an explicit object schema, but `list_scheduled_tasks` previously emitted `null`.

## Changes

- Adds a shared `parametersOrEmptyObject()` fallback for tool schemas.
- Ensures Google, Claude, and OpenAI providers serialize missing tool parameters as an empty object schema.
- Updates `list_scheduled_tasks` to explicitly declare an empty object parameter schema.
