### PR TITLE
fix: filter invalid Gemini content parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ settings.local.json
 /.gradle-user
 /.jdks
 .claude/settings.local.json
+.alma-snapshots

--- a/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
@@ -673,95 +673,102 @@ class GoogleProvider(private val client: OkHttpClient) : Provider<ProviderSettin
         return buildJsonArray {
             messages
                 .filter { it.role != MessageRole.SYSTEM && it.isValidToUpload() }
-                .forEachIndexed { index, message ->
-                    add(buildJsonObject {
-                        put("role", commonRoleToGoogleRole(message.role))
-                        putJsonArray("parts") {
-                            for (part in message.parts) {
-                                when (part) {
-                                    is UIMessagePart.Text -> {
+                .forEach { message ->
+                    val parts = buildJsonArray {
+                        for (part in message.parts) {
+                            when (part) {
+                                is UIMessagePart.Text -> {
+                                    if (part.text.isBlank()) continue
+                                    add(buildJsonObject {
+                                        put("text", part.text)
+                                        part.metadata?.get("thoughtSignature")?.let {
+                                            put("thoughtSignature", it)
+                                        }
+                                    })
+                                }
+
+                                is UIMessagePart.Image -> {
+                                    part.encodeBase64(false).onSuccess { base64Data ->
                                         add(buildJsonObject {
-                                            put("text", part.text)
-                                            part.metadata?.get("thoughtSignature")?.let {
-                                                put("thoughtSignature", it)
-                                            }
-                                        })
-                                    }
-
-                                    is UIMessagePart.Image -> {
-                                        part.encodeBase64(false).onSuccess { base64Data ->
-                                            add(buildJsonObject {
-                                                put("inline_data", buildJsonObject {
-                                                    put("mime_type", "image/png")
-                                                    put("data", base64Data)
-                                                })
-                                                part.metadata?.get("thoughtSignature")?.let {
-                                                    put("thoughtSignature", it)
-                                                }
-                                            })
-                                        }
-                                    }
-
-                                    is UIMessagePart.Video -> {
-                                        part.encodeBase64(false).onSuccess { base64Data ->
-                                            add(buildJsonObject {
-                                                put("inline_data", buildJsonObject {
-                                                    put("mime_type", "video/mp4")
-                                                    put("data", base64Data)
-                                                })
-                                                part.metadata?.get("thoughtSignature")?.let {
-                                                    put("thoughtSignature", it)
-                                                }
-                                            })
-                                        }
-                                    }
-
-                                    is UIMessagePart.Audio -> {
-                                        part.encodeBase64(false).onSuccess { base64Data ->
-                                            add(buildJsonObject {
-                                                put("inline_data", buildJsonObject {
-                                                    put("mime_type", "audio/mp3")
-                                                    put("data", base64Data)
-                                                })
-                                                part.metadata?.get("thoughtSignature")?.let {
-                                                    put("thoughtSignature", it)
-                                                }
-                                            })
-                                        }
-                                    }
-
-                                    is UIMessagePart.ToolCall -> {
-                                        add(buildJsonObject {
-                                            put("functionCall", buildJsonObject {
-                                                put("name", part.toolName)
-                                                put("args", json.parseToJsonElement(part.arguments))
+                                            put("inlineData", buildJsonObject {
+                                                put("mimeType", "image/png")
+                                                put("data", base64Data.toGoogleInlineDataPayload())
                                             })
                                             part.metadata?.get("thoughtSignature")?.let {
                                                 put("thoughtSignature", it)
                                             }
                                         })
                                     }
+                                }
 
-                                    is UIMessagePart.ToolResult -> {
+                                is UIMessagePart.Video -> {
+                                    part.encodeBase64(false).onSuccess { base64Data ->
                                         add(buildJsonObject {
-                                            put("functionResponse", buildJsonObject {
-                                                put("name", part.toolName)
-                                                put("response", buildJsonObject {
-                                                    put("result", part.content)
-                                                })
+                                            put("inlineData", buildJsonObject {
+                                                put("mimeType", "video/mp4")
+                                                put("data", base64Data.toGoogleInlineDataPayload())
                                             })
+                                            part.metadata?.get("thoughtSignature")?.let {
+                                                put("thoughtSignature", it)
+                                            }
                                         })
                                     }
+                                }
 
-                                    else -> {
-                                        // Unsupported part type
+                                is UIMessagePart.Audio -> {
+                                    part.encodeBase64(false).onSuccess { base64Data ->
+                                        add(buildJsonObject {
+                                            put("inlineData", buildJsonObject {
+                                                put("mimeType", "audio/mp3")
+                                                put("data", base64Data.toGoogleInlineDataPayload())
+                                            })
+                                            part.metadata?.get("thoughtSignature")?.let {
+                                                put("thoughtSignature", it)
+                                            }
+                                        })
                                     }
+                                }
+
+                                is UIMessagePart.ToolCall -> {
+                                    add(buildJsonObject {
+                                        put("functionCall", buildJsonObject {
+                                            put("name", part.toolName)
+                                            put("args", json.parseToJsonElement(part.arguments))
+                                        })
+                                        part.metadata?.get("thoughtSignature")?.let {
+                                            put("thoughtSignature", it)
+                                        }
+                                    })
+                                }
+
+                                is UIMessagePart.ToolResult -> {
+                                    add(buildJsonObject {
+                                        put("functionResponse", buildJsonObject {
+                                            put("name", part.toolName)
+                                            put("response", buildJsonObject {
+                                                put("result", part.content)
+                                            })
+                                        })
+                                    })
+                                }
+
+                                else -> {
+                                    // Unsupported part type
                                 }
                             }
                         }
+                    }
+                    if (parts.isEmpty()) return@forEach
+                    add(buildJsonObject {
+                        put("role", commonRoleToGoogleRole(message.role))
+                        put("parts", parts)
                     })
                 }
         }
+    }
+
+    private fun String.toGoogleInlineDataPayload(): String {
+        return substringAfter("base64,", this)
     }
 
     private fun parseUsageMeta(jsonObject: JsonObject?): TokenUsage? {

--- a/ai/src/test/java/me/rerere/ai/provider/providers/GoogleProviderTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/GoogleProviderTest.kt
@@ -1,0 +1,94 @@
+package me.rerere.ai.provider.providers
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import me.rerere.ai.core.MessageRole
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GoogleProviderTest {
+    private fun buildContents(messages: List<UIMessage>): JsonArray {
+        val method = GoogleProvider::class.java.getDeclaredMethod(
+            "buildContents",
+            List::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(GoogleProvider(OkHttpClient()), messages) as JsonArray
+    }
+
+    @Test
+    fun `tool result messages should not upload blank text parts`() {
+        val contents = buildContents(
+            listOf(
+                UIMessage(role = MessageRole.USER, parts = listOf(UIMessagePart.Text("Run tool"))),
+                UIMessage(
+                    role = MessageRole.ASSISTANT,
+                    parts = listOf(
+                        UIMessagePart.ToolCall(
+                            toolCallId = "call_1",
+                            toolName = "lookup",
+                            arguments = "{}",
+                        )
+                    ),
+                ),
+                UIMessage(
+                    role = MessageRole.TOOL,
+                    parts = listOf(
+                        UIMessagePart.ToolResult(
+                            toolCallId = "call_1",
+                            toolName = "lookup",
+                            content = JsonPrimitive("ok"),
+                            arguments = JsonObject(emptyMap()),
+                        ),
+                        UIMessagePart.Text(""),
+                    ),
+                ),
+            )
+        )
+
+        val toolResultParts = contents[2].jsonObject["parts"]!!.jsonArray
+        assertEquals(1, toolResultParts.size)
+        assertNotNull(toolResultParts[0].jsonObject["functionResponse"])
+        assertNull(toolResultParts[0].jsonObject["text"])
+    }
+
+    @Test
+    fun `blank-only messages should be omitted from google contents`() {
+        val contents = buildContents(
+            listOf(
+                UIMessage(role = MessageRole.USER, parts = listOf(UIMessagePart.Text("   "))),
+            )
+        )
+
+        assertEquals(0, contents.size)
+    }
+
+    @Test
+    fun `image parts should use gemini camel case inline data fields`() {
+        val contents = buildContents(
+            listOf(
+                UIMessage(
+                    role = MessageRole.USER,
+                    parts = listOf(UIMessagePart.Image("data:image/png;base64,AAAA")),
+                ),
+            )
+        )
+
+        val imagePart = contents[0].jsonObject["parts"]!!.jsonArray[0].jsonObject
+        val inlineData = imagePart["inlineData"]!!.jsonObject
+        assertNotNull(inlineData["mimeType"])
+        assertEquals("AAAA", inlineData["data"]!!.jsonPrimitive.content)
+        assertFalse(imagePart.containsKey("inline_data"))
+        assertFalse(inlineData.containsKey("mime_type"))
+    }
+}


### PR DESCRIPTION
## Summary

Closes #69.

Fixes Gemini tool-call follow-up requests that can fail with HTTP 400 when the serialized Google `contents[].parts[]` payload contains a part without any initialized data oneof field.

## Rationale

The failing upstream error is:

```json
{
  "error": {
    "message": "* ***.contents[2].parts[1].data: required oneof field 'data' must have one initialized field\n",
    "type": "upstream_error",
    "code": 400
  }
}
```

Gemini `Content.Part` is a oneof-style payload: each part must initialize one valid data field, such as `text`, `inlineData`, `functionCall`, or `functionResponse`. Tool-call history can include a valid `functionResponse` plus an extra blank text part, which should not be uploaded as a Gemini part.

The canonical Google REST / ProtoJSON field names for inline media are lower camel case, including `inlineData` and `mimeType`:

- Vertex AI `Content.Part` / `Blob` REST reference: https://cloud.google.com/vertex-ai/docs/reference/rest/v1/Content
- ProtoJSON field-name mapping: https://protobuf.dev/programming-guides/json/

## Changes

- Filters Google/Gemini content parts before adding each `Content` object.
- Skips blank text parts and omits messages that have no valid uploadable parts after filtering.
- Uses `inlineData` / `mimeType` for Gemini inline media payloads.
- Strips `data:*;base64,` prefixes before sending `inlineData.data`.
- Adds unit coverage for tool-result history with a blank text part and inline media field serialization.